### PR TITLE
feat: Add mapping.json for db to API schema mapping based on JSON schema

### DIFF
--- a/notes/platform/database_json_schema_mapping.md
+++ b/notes/platform/database_json_schema_mapping.md
@@ -1,0 +1,135 @@
+# Database to JSON Schema Mapping Principles
+
+## Overview
+
+This document outlines the standardized approach for mapping database types to JSON Schema across different database systems (PostgreSQL, DuckDB, MySQL, etc.) while maintaining data integrity and compatibility.
+
+## Core Principles
+
+1. Type Standardization
+   - Use the most inclusive numeric type for each database
+   - Maintain consistent type mapping across different databases
+   - Preserve precision and scale where applicable
+
+2. Schema Organization
+   - Each database connector maintains its own mapping.json
+   - Common type definitions shared across databases
+   - Database-specific types handled individually
+
+3. Type Categories
+
+### Numeric Types
+- Integer Types  ```json
+  {
+    "type": "integer",
+    "minimum": -9223372036854775808,
+    "maximum": 9223372036854775807
+  }  ```
+- Decimal/Numeric Types  ```json
+  {
+    "type": "string",
+    "format": "decimal"
+  }  ```
+
+### String Types
+- Character Types (VARCHAR, TEXT, CHAR)
+- Binary Types (BLOB, BYTEA)
+- Specialized Types (UUID, JSON)
+
+### Temporal Types
+- Timestamp Types (with/without timezone)
+- Date Types
+- Time Types
+- Interval/Duration Types
+
+### Complex Types
+- Arrays/Lists
+- Structured Types (STRUCT, ROW)
+- Key-Value Types (MAP, HSTORE)
+
+## Implementation Guidelines
+
+1. Mapping File Structure   ```
+   database_connector/
+   ├── mapping.json
+   ├── connection_specification.json
+   └── metadata.json   ```
+
+2. Type Resolution Rules
+   - Always map to the most precise compatible JSON Schema type
+   - Handle NULL values consistently across all types
+   - Support array types through nested schemas
+
+3. Database-Specific Considerations
+
+   PostgreSQL:
+   - Handle custom types
+   - Support for arrays and composites
+   - JSONB specific handling
+
+   DuckDB:
+   - Struct and Map types
+   - Time precision handling
+   - List type support
+
+   MySQL:
+   - ENUM type handling
+   - Spatial data types
+   - JSON type support
+
+## Best Practices
+
+1. Type Mapping
+   - Use references ($ref) for common types
+   - Maintain explicit NULL handling
+   - Document precision/scale requirements
+
+2. Schema Evolution
+   - Version control for mappings
+   - Backward compatibility support
+   - Migration path documentation
+
+3. Validation
+   - Format validation for specialized types
+   - Range validation for numeric types
+   - Pattern validation for structured strings
+
+## Example Implementation
+
+Reference the mapping.json structure: 
+
+json:ruby_connectors/lib/ruby_connectors/duckdb_connector/mapping.json
+
+## Integration Points
+
+1. ETL Pipeline
+   - Type conversion during data extraction
+   - Validation during transformation
+   - Load-time type checking
+
+2. Schema Management
+   - Automatic schema generation
+   - Schema validation
+   - Type inference
+
+3. Error Handling
+   - Type conversion errors
+   - Validation failures
+   - Precision loss detection
+
+## Future Considerations
+
+1. Extensibility
+   - Support for new database types
+   - Custom type mapping definitions
+   - Plugin system for type handlers
+
+2. Performance
+   - Caching of type definitions
+   - Optimized validation
+   - Batch processing support
+
+3. Monitoring
+   - Type conversion metrics
+   - Validation success rates
+   - Schema evolution tracking 

--- a/platform/app/blueprints/sync_blueprint.rb
+++ b/platform/app/blueprints/sync_blueprint.rb
@@ -7,5 +7,5 @@ class SyncBlueprint < Blueprinter::Base
          :sync_frequency, :schema, :supported_sync_modes,
          :source_defined_cursor, :default_cursor_field,
          :source_defined_primary_key, :destination_sync_mode,
-         :created_at, :updated_at
+         :destination_database_schema, :created_at, :updated_at
 end

--- a/platform/app/services/syncs/destination_schema_normalizer_service.rb
+++ b/platform/app/services/syncs/destination_schema_normalizer_service.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+module Syncs
+  # rubocop:disable Metrics/ClassLength
+  class DestinationSchemaNormalizerService
+    def initialize(sync)
+      @sync = sync
+      @source_connector = sync.connection.source
+      @destination_connector = sync.connection.destination
+      @stream_name = sync.stream_name
+      @workspace_id = sync.connection.workspace_id
+    end
+
+    def call
+      return nil unless database_destination?
+
+      {
+        database: generate_database_name,
+        schema_name: schema_support? ? generate_schema_name : nil,
+        table_name: generate_table_name(@stream_name),
+        table_schema: generate_table_schema,
+        mapping: generate_mapping
+      }
+    end
+
+    private
+
+    def generate_table_schema
+      schema = {
+        "_polymetrics_id" => map_field_type({ "type" => "string" })["type"],
+        "_polymetrics_extracted_at" => map_field_type({ "type" => "string", "format" => "date-time" })["type"]
+      }
+
+      if source_schema && source_schema["properties"]
+        source_schema["properties"].each do |field_name, field_definition|
+          schema[field_name.to_s] = map_field_type(field_definition)["type"]
+        end
+      end
+
+      schema
+    end
+
+    def generate_mapping
+      default_mappings + source_field_mappings
+    end
+
+    def default_mappings
+      [
+        {
+          from: "_polymetrics_id",
+          to: "_polymetrics_id",
+          type: "signature"
+        },
+        {
+          from: "_polymetrics_extracted_at",
+          to: "_polymetrics_extracted_at",
+          type: "current_timestamp"
+        }
+      ]
+    end
+
+    def source_field_mappings
+      return [] unless source_schema["properties"]
+
+      source_schema["properties"].keys.map do |field_name|
+        {
+          from: field_name,
+          to: field_name,
+          type: "default"
+        }
+      end
+    end
+
+    def map_field_type(field_schema)
+      mapping = load_destination_mapping
+
+      type = extract_non_null_type(field_schema["type"])
+      format = field_schema["format"]
+
+      db_type = if format && mapping[:format_mappings]&.[](format)
+                  mapping[:format_mappings][format]
+                elsif type && mapping[:type_mappings]&.[](type)
+                  mapping[:type_mappings][type]
+                else
+                  mapping[:default]
+                end
+
+      { "type" => db_type }
+    end
+
+    def extract_non_null_type(type)
+      return type unless type.is_a?(Array)
+
+      non_null_types = type.reject { |t| t == "null" }
+      non_null_types.first || "string"
+    end
+
+    def generate_schema_name
+      source_name = @sync.connection.source.name.downcase
+                         .parameterize(separator: "_")
+                         .gsub(/[^a-z0-9_]/, "")
+      workspace_hash = Digest::SHA256.hexdigest(@workspace_id.to_s)[0..7]
+
+      "source_#{source_name}_#{workspace_hash}"
+    end
+
+    def generate_database_name
+      org_name = @sync.connection.workspace.organization.name
+                      .downcase
+                      .parameterize(separator: "_")
+                      .gsub(/[^a-z0-9_]/, "")
+      environment = Rails.env
+
+      "#{org_name}_#{environment}"
+    end
+
+    def generate_table_name(base_name)
+      if schema_support?
+        base_name
+      else
+        "#{generate_schema_name}_#{base_name}"
+      end
+    end
+
+    def schema_support?
+      @schema_support ||= begin
+        metadata = load_destination_metadata
+        metadata.dig("features", "schema_support") || false
+      rescue StandardError => e
+        Rails.logger.error("Error loading metadata file: #{e.message}")
+        false
+      end
+    end
+
+    def load_destination_metadata
+      path = metadata_file_path
+      JSON.parse(File.read(path))
+    end
+
+    def load_destination_mapping
+      @load_destination_mapping ||= begin
+        path = mapping_file_path
+        JSON.parse(File.read(path)).with_indifferent_access
+      rescue StandardError => e
+        Rails.logger.error("Error loading mapping file: #{e.message}")
+        {}
+      end
+    end
+
+    def metadata_file_path
+      build_connector_file_path("metadata.json")
+    end
+
+    def mapping_file_path
+      build_connector_file_path("mapping.json")
+    end
+
+    def build_connector_file_path(filename)
+      connector_folder = "#{@destination_connector.connector_class_name.underscore}_connector"
+      Rails.root.join("..", "ruby_connectors", "lib", "ruby_connectors",
+                      connector_folder, filename)
+    end
+
+    def database_destination?
+      @destination_connector.integration_type == "database"
+    end
+
+    def source_schema
+      @source_schema ||= @sync.schema || {}
+    end
+  end
+  # rubocop:enable Metrics/ClassLength
+end

--- a/platform/db/migrate/20241218213242_add_destination_database_schema_to_syncs.rb
+++ b/platform/db/migrate/20241218213242_add_destination_database_schema_to_syncs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDestinationDatabaseSchemaToSyncs < ActiveRecord::Migration[7.1]
+  def change
+    add_column :syncs, :destination_database_schema, :jsonb
+  end
+end

--- a/platform/db/schema.rb
+++ b/platform/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_12_171452) do
+ActiveRecord::Schema[7.1].define(version: 2024_12_18_213242) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -148,6 +148,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_12_171452) do
     t.string "destination_sync_mode"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "destination_database_schema"
     t.index ["connection_id", "stream_name"], name: "index_syncs_on_connection_id_and_stream_name", unique: true
     t.index ["connection_id"], name: "index_syncs_on_connection_id"
   end

--- a/platform/spec/blueprints/sync_blueprint_spec.rb
+++ b/platform/spec/blueprints/sync_blueprint_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe SyncBlueprint do
           :sync_frequency, :schema, :supported_sync_modes,
           :source_defined_cursor, :default_cursor_field,
           :source_defined_primary_key, :destination_sync_mode,
+          :destination_database_schema,
           :created_at, :updated_at
         )
       end

--- a/platform/spec/services/syncs/create_service_spec.rb
+++ b/platform/spec/services/syncs/create_service_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Syncs::CreateService do
       {
         "stream1" => {
           "name" => "stream1",
+          "properties" => {
+            "id" => { "type" => "integer" },
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "created_at" => { "type" => "string", "format" => "date-time" }
+          },
           "x-supported_sync_modes" => %w[full_refresh incremental],
           "x-default_sync_mode" => "incremental",
           "x-source_defined_cursor" => true,
@@ -17,11 +23,19 @@ RSpec.describe Syncs::CreateService do
         },
         "stream2" => {
           "name" => "stream2",
+          "properties" => {
+            "id" => { "type" => "integer" },
+            "name" => { "type" => "string" }
+          },
           "x-supported_sync_modes" => ["full_refresh"],
           "x-default_sync_mode" => "full_refresh"
         },
         "stream3" => {
           "name" => "stream3",
+          "properties" => {
+            "id" => { "type" => "integer" },
+            "name" => { "type" => "string" }
+          },
           "x-supported_sync_modes" => ["incremental"],
           "x-default_sync_mode" => "incremental",
           "x-source_defined_cursor" => true,

--- a/platform/spec/services/syncs/destination_schema_normalizer_service_spec.rb
+++ b/platform/spec/services/syncs/destination_schema_normalizer_service_spec.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Syncs::DestinationSchemaNormalizerService do
+  let(:workspace) { create(:workspace) }
+  let(:source_connector) { create(:connector, workspace: workspace) }
+  let(:destination_connector) { create(:connector, workspace: workspace, integration_type: "database") }
+  let(:connection) { create(:connection, workspace: workspace, source: source_connector, destination: destination_connector) }
+  let(:sync) { create(:sync, connection: connection, stream_name: "users", schema: source_schema) }
+  let(:service) { described_class.new(sync) }
+
+  let(:source_schema) do
+    {
+      properties: {
+        id: { type: "integer" },
+        name: { type: "string" },
+        email: { type: "string" },
+        created_at: { type: "string", format: "date-time" },
+        is_active: { type: "boolean" },
+        score: { type: "number" },
+        nullable_field: { type: %w[null string] }
+      }
+    }
+  end
+
+  describe "#call" do
+    context "when destination is not a database" do
+      before do
+        destination_connector.update!(integration_type: "api")
+      end
+
+      it "returns nil" do
+        expect(service.call).to be_nil
+      end
+    end
+
+    context "when destination is a database" do
+      let(:mapping_json) do
+        {
+          default: "VARCHAR",
+          type_mappings: {
+            integer: "BIGINT",
+            number: "DOUBLE",
+            string: "VARCHAR",
+            boolean: "BOOLEAN"
+          },
+          format_mappings: {
+            "date-time": "TIMESTAMP",
+            date: "DATE",
+            time: "TIME"
+          }
+        }
+      end
+
+      let(:metadata_json) do
+        {
+          features: {
+            schema_support: true
+          }
+        }
+      end
+
+      before do
+        allow(File).to receive(:read).with(anything) do |path|
+          if path.to_s.end_with?("mapping.json")
+            mapping_json.to_json
+          elsif path.to_s.end_with?("metadata.json")
+            metadata_json.to_json
+          end
+        end
+      end
+
+      it "returns all required schema keys" do
+        result = service.call
+
+        expect(result).to include(
+          :database,
+          :schema_name,
+          :table_name,
+          :table_schema,
+          :mapping
+        )
+      end
+
+      it "generates correct database and schema names" do
+        result = service.call
+
+        expect(result[:database]).to match(/\w+_test$/)
+        expect(result[:schema_name]).to match(/^source_\w+_[a-f0-9]{8}$/)
+        expect(result[:table_name]).to eq("users")
+      end
+
+      it "generates correct table schema" do
+        result = service.call
+
+        expect(result[:table_schema]).to eq(
+          "_polymetrics_id" => "VARCHAR",
+          "_polymetrics_extracted_at" => "TIMESTAMP",
+          "id" => "BIGINT",
+          "name" => "VARCHAR",
+          "email" => "VARCHAR",
+          "created_at" => "TIMESTAMP",
+          "is_active" => "BOOLEAN",
+          "score" => "DOUBLE",
+          "nullable_field" => "VARCHAR"
+        )
+      end
+
+      it "includes correct mapping entries" do
+        result = service.call
+
+        expect(result[:mapping]).to include(
+          {
+            from: "_polymetrics_id",
+            to: "_polymetrics_id",
+            type: "signature"
+          },
+          {
+            from: "_polymetrics_extracted_at",
+            to: "_polymetrics_extracted_at",
+            type: "current_timestamp"
+          }
+        )
+      end
+
+      context "when schema support is disabled" do
+        let(:metadata_json) do
+          {
+            "features" => {
+              "schema_support" => false
+            }
+          }
+        end
+
+        it "returns nil for schema_name and prefixes table name" do
+          result = service.call
+
+          expect(result[:schema_name]).to be_nil
+          expect(result[:table_name]).to match(/source_\w+_[a-f0-9]{8}_users/)
+        end
+      end
+
+      context "when mapping file is not found" do
+        before do
+          allow(File).to receive(:read).with(/mapping\.json/).and_raise(StandardError)
+        end
+
+        it "uses default mappings" do
+          result = service.call
+
+          expect(result[:table_schema]).to include(
+            "id" => "BIGINT",
+            "name" => "VARCHAR"
+          )
+        end
+      end
+    end
+  end
+
+  describe "private methods" do
+    describe "#extract_non_null_type" do
+      it "handles single type" do
+        result = service.send(:extract_non_null_type, "string")
+        expect(result).to eq("string")
+      end
+
+      it "handles array with null type" do
+        result = service.send(:extract_non_null_type, %w[null string])
+        expect(result).to eq("string")
+      end
+
+      it "returns string for empty array" do
+        result = service.send(:extract_non_null_type, [])
+        expect(result).to eq("string")
+      end
+    end
+
+    describe "#generate_schema_name" do
+      it "generates a valid schema name" do
+        result = service.send(:generate_schema_name)
+        expect(result).to match(/^source_[a-z0-9_]+_[a-f0-9]{8}$/)
+      end
+    end
+
+    describe "#generate_database_name" do
+      it "generates a valid database name" do
+        result = service.send(:generate_database_name)
+        expect(result).to match(/^[a-z0-9_]+_test$/)
+      end
+    end
+  end
+end

--- a/ruby_connectors/lib/ruby_connectors/duckdb_connector/mapping.json
+++ b/ruby_connectors/lib/ruby_connectors/duckdb_connector/mapping.json
@@ -1,0 +1,19 @@
+{
+  "default": "VARCHAR",
+  "type_mappings": {
+    "integer": "BIGINT",
+    "number": "DOUBLE",
+    "string": "VARCHAR",
+    "boolean": "BOOLEAN",
+    "object": "JSON",
+    "array": "JSON"
+  },
+  "format_mappings": {
+    "date-time": "TIMESTAMP",
+    "date": "DATE",
+    "time": "TIME",
+    "uuid": "UUID",
+    "decimal": "DECIMAL",
+    "binary": "BLOB"
+  }
+} 

--- a/ruby_connectors/lib/ruby_connectors/duckdb_connector/metadata.json
+++ b/ruby_connectors/lib/ruby_connectors/duckdb_connector/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "DuckDB",
+  "type": "database",
+  "version": "1.0.0",
+  "features": {
+    "schema_support": true,
+    "incremental_support": true,
+    "bulk_load_support": true,
+    "transaction_support": true
+  },
+  "supported_sync_modes": [
+    "full_refresh",
+    "incremental"
+  ],
+  "supported_destination_sync_modes": [
+    "append",
+    "overwrite",
+    "upsert"
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new document outlining "Database to JSON Schema Mapping Principles" for better data mapping across various database systems.
	- Introduced a new field `:destination_database_schema` in the sync output.
	- Launched a new service for normalizing destination schemas to enhance data synchronization processes.
	- New JSON files added for DuckDB type mappings and metadata, facilitating data type compatibility.

- **Bug Fixes**
	- Improved error handling and validation in the schema normalization service.

- **Tests**
	- Added comprehensive test suites for the new schema normalization service and updated tests for sync creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->